### PR TITLE
Preserve ~/work directory with PersistentVolumeClaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 [Jupyter](https://jupyter.org/) notebook on Staroid.
 
+Features
+
+ - Jupyter Lab
+ - Persistent storage for `~/work`
+ - Kubernetes support
+ - Run on the cloud in a few clicks
+
 [![Run](https://staroid.com/api/run/button.svg)](https://staroid.com/api/run)
+
 
 ## Branch
 
@@ -17,7 +25,7 @@ This project uses [pre-built docker images](https://github.com/jupyter/docker-st
 Run locally with [skaffold](https://skaffold.dev) command.
 
 ```
-$ skaffold dev --port-forward
+$ skaffold dev --port-forward -p minikube
 ```
 
 and browse `http://localhost:8888`

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -55,6 +55,7 @@ metadata:
     storage.staroid.com/scope: Instance
     storage.staroid.com/file-manager: "1000:100"
 spec:
+  storageClassName: nfs
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -28,6 +28,13 @@ spec:
           requests:
             memory: 1G
             cpu: 1
+        volumeMounts:
+          - name: work-volume
+            mountPath: /home/jovyan/work
+      volumes:
+        - name: work-volume
+          persistentVolumeClaim:
+            claimName: work
 ---
 kind: Service
 apiVersion: v1
@@ -39,3 +46,18 @@ spec:
     port: 8888
   selector:
     app: jupyter
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: work
+  annotations:
+    storage.staroid.com/scope: Instance
+    storage.staroid.com/file-manager: "1000:100"
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/minikube.yaml
+++ b/minikube.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: jupyter-work-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: ./jupyter-work-pv
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: nfs
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+provisioner: k8s.io/minikube-hostpath

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,3 +4,9 @@ deploy:
   kubectl:
     manifests:
     - k8s.yaml
+profiles:
+  - name: minikube
+    patches:
+      - op: add
+        path: /deploy/kubectl/manifests/0
+        value: minikube.yaml


### PR DESCRIPTION
Jupyer docker image intended to preserve `~/work` directory.

https://jupyter-docker-stacks.readthedocs.io/en/latest/

> Docker destroys the container after notebook server exit, but any files written to ~/work in the container remain intact on the host.:

This PR creates PVC based on nfs (see https://docs.staroid.com/virtual_cloud/storage.html).
