### PR TITLE
Use dedicated node

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -4,6 +4,8 @@ metadata:
   name: jupyter-deployment
 spec:
   replicas: 1
+  strategy:
+    type: "Recreate"
   selector:
     matchLabels:
       app: jupyter
@@ -11,6 +13,8 @@ spec:
     metadata:
       labels:
         app: jupyter
+        pod.staroid.com/isolation: dedicated
+        pod.staroid.com/instance-type: standard-2
     spec:
       automountServiceAccountToken: true
       securityContext:
@@ -35,10 +39,6 @@ spec:
         envFrom:
         - configMapRef:
             name: mlflow-env
-        resources:
-          requests:
-            memory: 1G
-            cpu: 1
         volumeMounts:
           - name: work-volume
             mountPath: /home/jovyan/work

--- a/staroid.yaml
+++ b/staroid.yaml
@@ -13,24 +13,12 @@ deploy:
   paramGroups:
   - name: Configurations
     params:
-    - name: Memory
-      type: MEMORY
-      defaultValue: 2G
+    - name: "Instance type"
+      type: STRING
+      defaultValue: standard-2
       options:
-      - name: 2G
-      - name: 4G
-      - name: 8G
-      - name: 16G
-      - name: 32G
+      - name: standard-2
+      - name: standard-4
+      - name: standard-8
       paths:
-      - Deployment:jupyter-deployment:spec.template.spec.containers[0].resources.requests.memory
-    - name: Cpu
-      type: CPU
-      defaultValue: 1
-      options:
-      - name: 1
-      - name: 2
-      - name: 4
-      - name: 8
-      paths:
-      - Deployment:jupyter-deployment:spec.template.spec.containers[0].resources.requests.cpu
+      - Deployment:jupyter-deployment:spec.template.metadata.labels["pod.staroid.com/instance-type"]


### PR DESCRIPTION
Run jupyter Pod on dedicated node.

 - A Jupyter Pod doesn't have to scale out, frequently recreated. So bootstrap overhead of dedicated node is not critical.
 - Potential operations of jupyter notebook may depends on iops. And dedicated node provides better iops, which results better user experience.
(even pip install <some package> may copy lots of small files)
 - In the future GPU support will be only available to dedicated node.