### PR TITLE
pre-install pysftp in conda environment (workaround)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
 FROM jupyter/minimal-notebook
 
 USER 0
-
 # RUN apt-get update && apt-get install -y openssh-client && \
 #    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 
-ADD requirements.txt ./
-RUN pip --no-cache-dir install -r requirements.txt && rm -f requirements.txt
+ADD requirements.txt /home/jovyan/.requirements.txt
+RUN pip --no-cache-dir install -r /home/jovyan/.requirements.txt
+
+# mlflow creates new conda environment for run (i.e. mlflow run ...) and some dependencies need to be added.
+# for example, pysftp is required to access artifact storage.
+#
+# .condarc is not working with --file flag (i.e. conda env create --file ... see https://github.com/conda/conda/issues/9580)
+# there should be other way to add additional dependencies.
+#
+# as a workaround, adding a pip install command to at the end of activate function in,
+#   - /opt/conda/etc/profiles.d/conda.sh
+#   - /opt/conda/lib/python3.x/site-packages/conda/shell/etc/profile.d/conda.sh (conda init bash command will rewrite /opt/conda/etc/profiles.d/conda.sh using this)
+# while mlflow 'source' this file to run 'conda activate'
+# (see https://github.com/mlflow/mlflow/blob/6ef63a7f33ebfe3481ea57cacd94a8a32fc7efd8/mlflow/projects/__init__.py#L493)
+RUN find /opt/conda -name conda.sh | xargs sed -i 's/__conda_hashr$/&\n    pip install -q -r \/home\/jovyan\/\.requirements\.txt/'

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -32,7 +32,7 @@ spec:
           echo $MLFLOW_ARTIFACT_STORE_RSA_PUB | base64 --decode >> ~/.ssh/known_hosts &&
           echo $MLFLOW_ARTIFACT_STORE_RSA_PRI | base64 --decode >> ~/.ssh/id_rsa &&
           chmod 600 ~/.ssh/* &&
-          jupyter-lab --ip='*' --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*' --debug
+          jupyter-lab --ip='*' --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.allow_origin='*'
         env:
         - name: JUPYTER_ENABLE_LAB
           value: "yes"


### PR DESCRIPTION
Follow up #4.

`mlflow run` creates conda environment to run job.
However, created conda environment doesn't have pysftp dependencies, while generated conda.yaml in the model doesn't have it.

Ideally, [create_default_packages](https://docs.conda.io/projects/conda/en/latest/user-guide/configuration/use-condarc.html#always-add-packages-by-default-create-default-packages) in `.condarc` should be the simple solution to add default pacakges for conda environment created.

However, there is a [bug](https://github.com/conda/conda/issues/9580) that `.condarc` is not working in case the environment is created with `--file` flag.

This PR implement workaround that mimics `.condarc` to install additional packages.
