### PR TITLE
Bumpup python version from 3.7 to 3.8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,6 @@
 # https://skaffold.dev/docs/pipeline-stages/builders/custom/
 #
 
-echo "image -- $IMAGE;"
 DOCKER_STACK_COMMIT=1a66dd36ff821bcef814afe86dbc3dba8cd2198d
 GPU_JUPYTER_COMMIT=3c350f0c933156edb49ebccb23142b890c232df6
 

--- a/build.sh
+++ b/build.sh
@@ -3,13 +3,17 @@
 # https://skaffold.dev/docs/pipeline-stages/builders/custom/
 #
 
+echo "image -- $IMAGE;"
+DOCKER_STACK_COMMIT=1a66dd36ff821bcef814afe86dbc3dba8cd2198d
+GPU_JUPYTER_COMMIT=3c350f0c933156edb49ebccb23142b890c232df6
+
 # Generate jupyter docker image using nvidia docker for gpu support.
 # Otherwise, Dockerfile_staroid would be enough.
 git clone https://github.com/iot-salzburg/gpu-jupyter.git
 cd gpu-jupyter
+git checkout $GPU_JUPYTER_COMMIT
 
 # generate Dockerfile
-DOCKER_STACK_COMMIT=1a66dd36ff821bcef814afe86dbc3dba8cd2198d
 ./generate-Dockerfile.sh -c ${DOCKER_STACK_COMMIT} -s --no-datascience-notebook --no-useful-packages
 cd .build
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,8 @@ git clone https://github.com/iot-salzburg/gpu-jupyter.git
 cd gpu-jupyter
 
 # generate Dockerfile
-./generate-Dockerfile.sh -s --no-datascience-notebook --no-useful-packages
+DOCKER_STACK_COMMIT=1a66dd36ff821bcef814afe86dbc3dba8cd2198d
+./generate-Dockerfile.sh -c ${DOCKER_STACK_COMMIT} -s --no-datascience-notebook --no-useful-packages
 cd .build
 
 # patch Dockerfile. Want to keep minimal jupyter on gpu

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,11 +7,10 @@ build:
       custom:
         # staroid build env allow executable in /var/run.
         buildCommand: >
-          echo "image - $IMAGE;" &&
           sudo mkdir /var/run/repo &&
           sudo cp -r * /var/run/repo/ &&
           sudo chown crs:crs -R /var/run/repo &&
-          cd /var/run/repo &&          
+          cd /var/run/repo &&
           ./build.sh
 deploy:
   kubectl:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,6 +7,7 @@ build:
       custom:
         # staroid build env allow executable in /var/run.
         buildCommand: >
+          pwd && ls -al &&
           ./build.sh
 deploy:
   kubectl:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,9 +10,9 @@ build:
           echo "image - $IMAGE;" &&
           sudo mkdir /var/run/repo &&
           sudo cp -r * /var/run/repo/ &&
-          cd /var/run/repo &&
-          sudo ./build.sh &&
-          IMAGE=$IMAGE PUSH_IMAGE=$PUSH_IMAGE /var/run/build.sh
+          chown crs:crs -R /var/run/repo &&
+          cd /var/run/repo &&          
+          ./build.sh
 deploy:
   kubectl:
     manifests:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,6 +7,7 @@ build:
       custom:
         # staroid build env allow executable in /var/run.
         buildCommand: >
+          echo "image - $IMAGE;" &&
           sudo mkdir /var/run/repo &&
           sudo cp -r * /var/run/repo/ &&
           cd /var/run/repo &&

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,10 +7,6 @@ build:
       custom:
         # staroid build env allow executable in /var/run.
         buildCommand: >
-          sudo mkdir /var/run/repo &&
-          sudo cp -r * /var/run/repo/ &&
-          sudo chown crs:crs -R /var/run/repo &&
-          cd /var/run/repo &&
           ./build.sh
 deploy:
   kubectl:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -5,10 +5,7 @@ build:
     - image: jupyter
       context: .
       custom:
-        # staroid build env allow executable in /var/run.
-        buildCommand: >
-          pwd && ls -al &&
-          ./build.sh
+        buildCommand: ./build.sh
 deploy:
   kubectl:
     manifests:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,7 +12,7 @@ build:
           sudo cp -r * /var/run/repo/ &&
           cd /var/run/repo &&
           sudo ./build.sh &&
-          /var/run/build.sh
+          IMAGE=$IMAGE PUSH_IMAGE=$PUSH_IMAGE /var/run/build.sh
 deploy:
   kubectl:
     manifests:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,12 @@ build:
       context: .
       custom:
         # staroid build env allow executable in /var/run.
-        buildCommand: sudo cp -v ./build.sh /var/run/ && /var/run/build.sh
+        buildCommand: >
+          ls -al &&
+          sudo mv workspace/repo /var/run/ &&
+          cd /var/run/repo &&
+          sudo ./build.sh &&
+          /var/run/build.sh
 deploy:
   kubectl:
     manifests:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,7 +10,7 @@ build:
           echo "image - $IMAGE;" &&
           sudo mkdir /var/run/repo &&
           sudo cp -r * /var/run/repo/ &&
-          chown crs:crs -R /var/run/repo &&
+          sudo chown crs:crs -R /var/run/repo &&
           cd /var/run/repo &&          
           ./build.sh
 deploy:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,8 +7,8 @@ build:
       custom:
         # staroid build env allow executable in /var/run.
         buildCommand: >
-          ls -al &&
-          sudo mv workspace/repo /var/run/ &&
+          sudo mkdir /var/run/repo &&
+          sudo cp -r * /var/run/repo/ &&
           cd /var/run/repo &&
           sudo ./build.sh &&
           /var/run/build.sh


### PR DESCRIPTION
Bumpup python version from 3.7 to 3.8.

- latest jupyter docker stack is based on python 3.8
- Dask kubernetes worker docker image is based on 3.8 and requires the same version. After upgrade to 3.8, it'll work out of the box.