### PR TITLE
Include popular packages by default.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,8 @@ git checkout $GPU_JUPYTER_COMMIT
 ./generate-Dockerfile.sh -c ${DOCKER_STACK_COMMIT} -s --no-datascience-notebook --no-useful-packages
 cd .build
 
-# patch Dockerfile. Want to keep minimal jupyter on gpu
-cat Dockerfile | awk '!p;/Dependency: jupyter\/scipy-notebook/{p=1}' > Dockerfile_minimal
+# patch Dockerfile.
+cat Dockerfile | awk '!p;/# Copy the demo notebooks/{p=1}' > Dockerfile_minimal
 
 # append staroid Dockerfile
 cat ../../Dockerfile_staroid | grep -v ^FROM >> Dockerfile_minimal


### PR DESCRIPTION
For now, docker image is optimized in terms of size to minimize download time at launch.
However, installing popular packages like pandas, numpy, pytouch, tensorflow, matplotlib, etc everytime is not only annoying but also could be tricky (e.g. pytouch need to be installed through conda instead of pip).

So it makes sense to have those packages installed by default although it may increase initial launch time.