### PR TITLE
Setup StarRank community rate and upstream projects

### DIFF
--- a/staroid.yaml
+++ b/staroid.yaml
@@ -1,6 +1,11 @@
 apiVersion: beta/v1
 starRank:
-  rate: 1.0
+  rate: 1.2
+  upstream:
+  - project: iot-salzburg/gpu-jupyter
+    weight: 100
+  - project: open-datastudio/jupyter
+    weight: 100
 build:
   skaffold: {}
 ingress:

--- a/staroid.yaml
+++ b/staroid.yaml
@@ -2,6 +2,8 @@ apiVersion: beta/v1
 starRank:
   rate: 1.2
   upstream:
+  - project: jupyter/notebook
+    weight: 100
   - project: iot-salzburg/gpu-jupyter
     weight: 100
   - project: open-datastudio/jupyter

--- a/staroid.yaml
+++ b/staroid.yaml
@@ -3,11 +3,11 @@ starRank:
   rate: 1.2
   upstream:
   - project: jupyter/notebook
-    weight: 100
+    weight: 200
   - project: iot-salzburg/gpu-jupyter
     weight: 100
   - project: open-datastudio/jupyter
-    weight: 100
+    weight: 50
 build:
   skaffold: {}
 ingress:


### PR DESCRIPTION
### Set StarRank community rate.

Currently, the rate is set to `1.0`. That means contributors to the projects are not getting funded. 
The proposed rate here is `1.2`, but please feel free to comment for a more reasonable number.

### Set upstream projects

If this project fork from another project, contributors to the original project will be automatically funded while the original project's contributors are already included in the commit history of the fork.

However, this project clone projects in build time. So it's better manually list upstream projects.
The initial upstream list I propose is

- https://github.com/jupyter/notebook - This project's primary function is providing a Jupyter notebook instance on the cloud
- https://github.com/iot-salzburg/gpu-jupyter - Docker image is built using gpu-jupyter project
- https://github.com/open-datastudio/jupyter - Maintaining integration to Staroid, Integration to other projects (like mlflow), example notebooks

The proposed weights are `200`:`100`:`50` respectively. Please feel free to comment for more reasonable numbers.


### Reference

https://staroid.com/site/starrank
https://staroid.com/site/pricing